### PR TITLE
Add Sony XBR RMT-TX200U and SoundblasterX remotes

### DIFF
--- a/SoundBars/Soundblasterx.ir
+++ b/SoundBars/Soundblasterx.ir
@@ -1,0 +1,44 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: Power
+type: parsed
+protocol: NECext
+address: 83 22 00 00
+command: 08 F7 00 00
+# 
+name: Mute
+type: parsed
+protocol: NECext
+address: 83 22 00 00
+command: 0C F3 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: NECext
+address: 83 22 00 00
+command: 0A F5 00 00
+# 
+name: Vol_down
+type: parsed
+protocol: NECext
+address: 83 22 00 00
+command: 01 FE 00 00
+# 
+name: Play_pause
+type: parsed
+protocol: NECext
+address: 83 22 00 00
+command: 09 F6 00 00
+# 
+name: Prev
+type: parsed
+protocol: NECext
+address: 83 22 00 00
+command: 07 F8 00 00
+# 
+name: Next
+type: parsed
+protocol: NECext
+address: 83 22 00 00
+command: 06 F9 00 00

--- a/TVs/Sonyxbr_RMT_TX200U.ir
+++ b/TVs/Sonyxbr_RMT_TX200U.ir
@@ -1,0 +1,44 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: Power
+type: parsed
+protocol: SIRC
+address: 01 00 00 00
+command: 15 00 00 00
+# 
+name: Input
+type: parsed
+protocol: SIRC
+address: 01 00 00 00
+command: 25 00 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: SIRC
+address: 01 00 00 00
+command: 12 00 00 00
+# 
+name: Vol_down
+type: parsed
+protocol: SIRC
+address: 01 00 00 00
+command: 13 00 00 00
+# 
+name: Ch_up
+type: parsed
+protocol: SIRC
+address: 01 00 00 00
+command: 10 00 00 00
+# 
+name: Ch_down
+type: parsed
+protocol: SIRC
+address: 01 00 00 00
+command: 11 00 00 00
+# 
+name: Mute
+type: parsed
+protocol: SIRC
+address: 01 00 00 00
+command: 14 00 00 00


### PR DESCRIPTION
The current Sony XBR remote file is specific to an unknown Sony XBR remote. The TX200U remote has different buttons and options (Power versus On/Off) that use different commands