### PR TITLE
Add two random IR captures

### DIFF
--- a/ACs/Koldfront_wac12001.ir
+++ b/ACs/Koldfront_wac12001.ir
@@ -1,0 +1,56 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: Power
+type: parsed
+protocol: NECext
+address: 01 FF 00 00
+command: 12 ED 00 00
+# 
+name: Mode
+type: parsed
+protocol: NECext
+address: 01 FF 00 00
+command: 02 FD 00 00
+# 
+name: Minus
+type: parsed
+protocol: NECext
+address: 01 FF 00 00
+command: 13 EC 00 00
+# 
+name: Plus
+type: parsed
+protocol: NECext
+address: 01 FF 00 00
+command: 1A E5 00 00
+# 
+name: Timer
+type: parsed
+protocol: NECext
+address: 01 FF 00 00
+command: 1B E4 00 00
+# 
+name: Speed
+type: parsed
+protocol: NECext
+address: 01 FF 00 00
+command: 0E F1 00 00
+# 
+name: One_Touch
+type: parsed
+protocol: NECext
+address: 01 FF 00 00
+command: 16 E9 00 00
+# 
+name: Sleep
+type: parsed
+protocol: NECext
+address: 01 FF 00 00
+command: 0A F5 00 00
+# 
+name: Energy_Saver
+type: parsed
+protocol: NECext
+address: 01 FF 00 00
+command: 0F F0 00 00

--- a/ETC/Jet_AFS-1000b.ir
+++ b/ETC/Jet_AFS-1000b.ir
@@ -1,0 +1,20 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: On_off
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 03 00 00 00
+# 
+name: Speed
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 07 00 00 00
+# 
+name: Time
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 0B 00 00 00


### PR DESCRIPTION
Here are two remotes captured via Flipper. One is for a Jet AFS-1000B air filtration system, typically used to clean dust and particles in a workshop. The other is for a Koldfront window AC unit, model WAC12001.