### PR TITLE
Cambridge Audio 650A Receiver & Gakken Worldeye

### DIFF
--- a/Audio_Receivers/CambridgeAudio/CambridgeAudio_650A.ir
+++ b/Audio_Receivers/CambridgeAudio/CambridgeAudio_650A.ir
@@ -1,0 +1,172 @@
+Filetype: IR signals file
+Version: 1
+#
+# Cambridge Audio 650A Receiver
+#
+name: On
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 0E 00 00 00
+#
+name: Off
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 0F 00 00 00
+#
+name: Vol+
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 10 00 00 00
+#
+name: Vol-
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 11 00 00 00
+#
+name: Mute
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 0D 00 00 00
+#
+name: Source
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 08 00 00 00
+#
+name: SpeakerAB
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 14 00 00 00
+#
+name: Eject
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 2D 00 00 00
+#
+name: Dash
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 0E 00 00 00
+#
+name: Prog
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 24 00 00 00
+#
+name: Left
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 21 00 00 00
+#
+name: Right
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 20 00 00 00
+#
+name: Select
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 35 00 00 00
+#
+name: Backward
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 2C 00 00 00
+#
+name: Forward
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 2B 00 00 00
+#
+name: Stop
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 36 00 00 00
+#
+name: Pause
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 30 00 00 00
+#
+name: Info
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 15 00 00 00
+#
+name: Brightness
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 28 00 00 00
+#
+name: Remain
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 3D 00 00 00
+#
+name: Random
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 1C 00 00 00
+#
+name: Repeat
+type: parsed
+protocol: RC5
+address: 14 00 00 00
+command: 1D 00 00 00
+#
+name: MP3
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 02 00 00 00
+#
+name: CD
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 05 00 00 00
+#
+name: TunerDAB
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 03 00 00 00
+#
+name: DVD
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 01 00 00 00
+#
+name: Aux
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 04 00 00 00
+#
+name: TapeMon
+type: parsed
+protocol: RC5
+address: 10 00 00 00
+command: 00 00 00 00

--- a/Miscellaneous/Gakken/Gakken_WorldEye.ir
+++ b/Miscellaneous/Gakken/Gakken_WorldEye.ir
@@ -1,0 +1,106 @@
+Filetype: IR signals file
+Version: 1
+#
+# Gakken WorldEye
+#
+name: Power
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 00 FF 00 00
+#
+name: Up
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 03 FC 00 00
+#
+name: Down
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 18 E7 00 00
+#
+name: Left
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 42 BD 00 00
+#
+name: Right
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 5D A2 00 00
+#
+name: OK
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 5E A1 00 00
+#
+name: Home
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 01 FE 00 00
+#
+name: Vol+
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 40 BF 00 00
+#
+name: Vol-
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 41 BE 00 00
+#
+name: Mute
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 13 EC 00 00
+#
+name: Clear
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 1A E5 00 00
+#
+name: Play_pause
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 16 E9 00 00
+#
+name: Back
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 1B E4 00 00
+#
+name: 1
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 02 FD 00 00
+#
+name: 2
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 07 F8 00 00
+#
+name: 3
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 05 FA 00 00
+#
+name: 4
+type: parsed
+protocol: NECext
+address: 80 63 00 00
+command: 06 F9 00 00


### PR DESCRIPTION
Add Cambridge Audio 650A under audio receivers.
Add Gakken Worldeye under miscellaenous.