### PR TITLE
Add Yamaha AX-380 Stereo Amplifier

### DIFF
--- a/Audio_Receivers/Yamaha/YAMAHA_AX-380.ir
+++ b/Audio_Receivers/Yamaha/YAMAHA_AX-380.ir
@@ -1,6 +1,8 @@
 Filetype: IR signals file
 Version: 1
 #
+# Yamaha AX-380 Stereo Amplifier
+#
 name: POWER
 type: parsed
 protocol: NEC

--- a/Audio_Receivers/Yamaha/YAMAHA_AX-380.ir
+++ b/Audio_Receivers/Yamaha/YAMAHA_AX-380.ir
@@ -1,0 +1,56 @@
+Filetype: IR signals file
+Version: 1
+#
+name: POWER
+type: parsed
+protocol: NEC
+address: 7A 00 00 00
+command: 1F 00 00 00
+# 
+name: VOL+
+type: parsed
+protocol: NEC
+address: 7A 00 00 00
+command: 1A 00 00 00
+# 
+name: VOL-
+type: parsed
+protocol: NEC
+address: 7A 00 00 00
+command: 1B 00 00 00
+# 
+name: INPUT_CD
+type: parsed
+protocol: NEC
+address: 7A 00 00 00
+command: 15 00 00 00
+# 
+name: INPUT_AUX
+type: parsed
+protocol: NEC
+address: 7A 00 00 00
+command: 17 00 00 00
+# 
+name: INPUT_TUNER
+type: parsed
+protocol: NEC
+address: 7A 00 00 00
+command: 16 00 00 00
+# 
+name: INPUT_PHONO
+type: parsed
+protocol: NEC
+address: 7A 00 00 00
+command: 14 00 00 00
+# 
+name: MONITOR_TAPE1
+type: parsed
+protocol: NEC
+address: 7A 00 00 00
+command: 18 00 00 00
+# 
+name: MONITOR_TAPE2
+type: parsed
+protocol: NEC
+address: 7A 00 00 00
+command: 19 00 00 00


### PR DESCRIPTION
The process of getting these was a bit convoluted to say the least.

Because I don't have a remote for the device, I had to rely on the information provided by the lirc project:
https://lirc.sourceforge.net/remotes/yamaha/VR50590
However, those codes were not flipper compatible, so to get those onto the flipper, I've used an ESP8266-based WiFi IR Blaster flashed with the Tasmota firmware to send those keycodes found in the lirc config (excluding the 0x00000000 prefix) and then let the Flipper decode that Signal.

There must be a less hacky solution to convert between these two formats but it worked decently for those nine keycodes.