### PR TITLE
Add GX-IR03 Gym/HIIT Clock remote

### DIFF
--- a/Miscellaneous/GX-IR03.ir
+++ b/Miscellaneous/GX-IR03.ir
@@ -1,0 +1,290 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: Power
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 0A 00 00 00
+# 
+name: Edit
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 0B 00 00 00
+# 
+name: Timer 1u
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 1E 00 00 00
+# 
+name: Timer 1d
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 5F 00 00 00
+# 
+name: Timer 2u
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 1F 00 00 00
+# 
+name: Timer 2d
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 5C 00 00 00
+# 
+name: Mute
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 1A 00 00 00
+# 
+name: Brightness
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 1B 00 00 00
+# 
+name: Pause
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 55 00 00 00
+# 
+name: Reset
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 5D 00 00 00
+# 
+name: Stop
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 59 00 00 00
+# 
+name: Start Up
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 5E 00 00 00
+# 
+name: Backspace Down
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 56 00 00 00
+# 
+name: Left
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 5B 00 00 00
+# 
+name: Right
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 58 00 00 00
+# 
+name: Enter Center
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 5A 00 00 00
+# 
+name: Cycle
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 57 00 00 00
+# 
+name: Alarm
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 54 00 00 00
+# 
+name: Red Clock
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 53 00 00 00
+# 
+name: Green Up
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 52 00 00 00
+# 
+name: Yellow Down
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 51 00 00 00
+# 
+name: Blue Stopwatch
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 50 00 00 00
+# 
+name: E1 12_24
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 4F 00 00 00
+# 
+name: E2 C_F
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 4E 00 00 00
+# 
+name: E3 DD_MM
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 4D 00 00 00
+# 
+name: E4 Zone
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 4C 00 00 00
+# 
+name: F1 Auto
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 4B 00 00 00
+# 
+name: F2 Time
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 4A 00 00 00
+# 
+name: F3 Date
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 49 00 00 00
+# 
+name: F4 Temp
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 48 00 00 00
+# 
+name: F5 X1
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 47 00 00 00
+# 
+name: F6 Y1
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 46 00 00 00
+# 
+name: F7 X2
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 45 00 00 00
+# 
+name: FPlus Y2
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 44 00 00 00
+# 
+name: A1
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 43 00 00 00
+# 
+name: A2
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 42 00 00 00
+# 
+name: A3
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 41 00 00 00
+# 
+name: APlus
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 40 00 00 00
+# 
+name: 1
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 0E 00 00 00
+# 
+name: 2
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 06 00 00 00
+# 
+name: 3
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 0F 00 00 00
+# 
+name: 4
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 12 00 00 00
+# 
+name: 5
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 07 00 00 00
+# 
+name: 6
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 13 00 00 00
+# 
+name: 7
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 16 00 00 00
+# 
+name: 8
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 02 00 00 00
+# 
+name: 9
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 17 00 00 00
+# 
+name: 0
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 03 00 00 00

--- a/Miscellaneous/Gym_HIIT/GX-IR03_Clock.ir
+++ b/Miscellaneous/Gym_HIIT/GX-IR03_Clock.ir
@@ -1,6 +1,9 @@
 Filetype: IR signals file
 Version: 1
 # 
+# Gym/HIIT Wall Clock GX-IR03
+# https://www.aliexpress.us/item/2255799914300348.html
+#
 name: Power
 type: parsed
 protocol: NEC


### PR DESCRIPTION
This is the full IR profile for the GX-IR03 remote that controls most AliExpress, Amazon, and other off-brand Gym/HIIT clocks.

Known to work with [this clock from AliExpress](https://www.aliexpress.us/item/2255799914300348.html) but will most likely work with most Interval Training clock