### PR TITLE
Create  Microlab_RC071.ir

### DIFF
--- a/Speakers/Microlab/Microlab_RC071.ir
+++ b/Speakers/Microlab/Microlab_RC071.ir
@@ -1,0 +1,59 @@
+Filetype: IR signals file
+Version: 1
+# 
+# Device: Microlab SOLO series (4C\5C\6C\7C)
+# Remote model: RC071
+#
+name: VOL+
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 11 00 00 00
+# 
+name: VOL-
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 10 00 00 00
+# 
+name: TREBLE+
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 09 00 00 00
+# 
+name: TREBLE-
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 0D 00 00 00
+# 
+name: BASS+
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 0A 00 00 00
+# 
+name: BASS-
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 0E 00 00 00
+# 
+name: RESET
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 08 00 00 00
+# 
+name: INPUT
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 04 00 00 00
+# 
+name: MUTE
+type: parsed
+protocol: NEC
+address: 01 00 00 00
+command: 02 00 00 00


### PR DESCRIPTION
Similar remote control in [this repo converted folder](https://github.com/Lucaslhm/Flipper-IRDB/blob/main/_Converted_/IR_Plus/M/MICROLAB/Speakers.ir) has similar codes, but in LSB first representation and encoding is NECext - that didn't work for me and I couldn't figure out how to fix it.

I grabbed the signal with a Flipper Zero from my [Arduino-based emulator](https://github.com/Alex-Tsarik/Arduino-IR-RC-Microlab-SOLO) (which works with speakers), and after understanding the conversion, added all the buttons. Tested with speakers Microlab SOLO 5c.