### PR TITLE
Gas Pump Programming Remote for Wayne Dresser Pumps

### DIFF
--- a/Miscellaneous/WayneDresser/WayneDresser_GasPump_Remote.ir
+++ b/Miscellaneous/WayneDresser/WayneDresser_GasPump_Remote.ir
@@ -1,0 +1,101 @@
+Filetype: IR signals file
+Version: 1
+# 
+# Wayne-Dresser gasoline dispenser technician programming controller ****** USE WITH CAUTION!!!! ****** Manuals can be found online, However if you dont know, id recommend not using it.
+# WILL ONLY WORK if the gasoline dispenser has been left enabled for remote control, technicians often forget to disable this function, passcode is sometimes changed as well.)
+#
+name: ENTER
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 00 FF 00 00
+# 
+name: CLEAR
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 10 EF 00 00
+# 
+name: 1
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 01 FE 00 00
+# 
+name: 2
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 09 F6 00 00
+# 
+name: 3
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 11 EE 00 00
+# 
+name: 4
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 02 FD 00 00
+# 
+name: 5
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 0A F5 00 00
+# 
+name: 6
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 12 ED 00 00
+# 
+name: 7
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 03 FC 00 00
+# 
+name: 8
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 0B F4 00 00
+# 
+name: 9
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 13 EC 00 00
+# 
+name: 0
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 0C F3 00 00
+# 
+name: POUND
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 0D F2 00 00
+# 
+name: UP
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 05 FA 00 00
+# 
+name: DOWN
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 06 F9 00 00
+# 
+name: NEXT
+type: parsed
+protocol: NECext
+address: 82 13 00 00
+command: 0E F1 00 00

--- a/Miscellaneous/WayneDresser/WayneDresser_GasPump_Remote.ir
+++ b/Miscellaneous/WayneDresser/WayneDresser_GasPump_Remote.ir
@@ -1,8 +1,8 @@
 Filetype: IR signals file
 Version: 1
 # 
-# Wayne-Dresser gasoline dispenser technician programming controller ****** USE WITH CAUTION!!!! ****** Manuals can be found online, However if you dont know, id recommend not using it.
-# WILL ONLY WORK if the gasoline dispenser has been left enabled for remote control, technicians often forget to disable this function, passcode is sometimes changed as well.)
+# Wayne-Dresser gasoline dispenser technician programming controller ****** USE WITH CAUTION!!!! ****** Manuals can be found online, However if you dont know, I'd recommend not using it.
+# (WILL ONLY WORK if the gasoline dispenser has been left enabled for remote control, technicians often forget to disable this function, passcode is sometimes changed as well.)
 #
 name: ENTER
 type: parsed


### PR DESCRIPTION
This ir file is all of the buttons on a gas pump technicians programming remote for a Wayne Dresser (Brand) gas pump. (Works with several models)
- a pass code is required to change programming, there is a default pass code.
- the "remote" function of the gas pumps can be disabled internally by a technician, so wont work on all of them unless they forgot to disable it.(happens a lot)

I am new to github and wanted to contribute something i think would be cool. I read these codes from my own remote.