### PR TITLE
Add NAD AMP 1 remote, included with NAD C 315BEE and many others.

### DIFF
--- a/Audio_Receivers/NAD/NAD_Amp_1.ir
+++ b/Audio_Receivers/NAD/NAD_Amp_1.ir
@@ -1,6 +1,8 @@
 Filetype: IR signals file
 Version: 1
 # 
+# NAD Audio Receiver
+#
 name: Power_on
 type: parsed
 protocol: NECext

--- a/Audio_Receivers/NAD_Amp_1.ir
+++ b/Audio_Receivers/NAD_Amp_1.ir
@@ -1,13 +1,13 @@
 Filetype: IR signals file
 Version: 1
 # 
-name: On
+name: Power_on
 type: parsed
 protocol: NECext
 address: 87 7C 00 00
 command: 25 DA 00 00
 # 
-name: Off
+name: Power_off
 type: parsed
 protocol: NECext
 address: 87 7C 00 00
@@ -19,13 +19,13 @@ protocol: NECext
 address: 87 7C 00 00
 command: 94 6B 00 00
 # 
-name: Vol_Up
+name: Vol_up
 type: parsed
 protocol: NECext
 address: 87 7C 00 00
 command: 88 77 00 00
 # 
-name: Vol_Down
+name: Vol_dn
 type: parsed
 protocol: NECext
 address: 87 7C 00 00

--- a/Audio_Receivers/NAD_Amp_1.ir
+++ b/Audio_Receivers/NAD_Amp_1.ir
@@ -1,0 +1,104 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: On
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 25 DA 00 00
+# 
+name: Off
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: C8 37 00 00
+# 
+name: Mute
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 94 6B 00 00
+# 
+name: Vol_Up
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 88 77 00 00
+# 
+name: Vol_Down
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 8C 73 00 00
+# 
+name: Aux
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 9B 64 00 00
+# 
+name: Disc
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 89 76 00 00
+# 
+name: CD
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 85 7A 00 00
+# 
+name: Video
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: C2 3D 00 00
+# 
+name: Tuner
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: DD 22 00 00
+# 
+name: Tape
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 8D 72 00 00
+# 
+name: Stop
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 02 FD 00 00
+# 
+name: Pause
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 4A B5 00 00
+# 
+name: Play
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 01 FE 00 00
+# 
+name: Eject
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 48 B7 00 00
+# 
+name: Prev_Track
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 05 FA 00 00
+# 
+name: Next_Track
+type: parsed
+protocol: NECext
+address: 87 7C 00 00
+command: 06 F9 00 00


### PR DESCRIPTION
Add a basic remote used with several NAD audio products.