### PR TITLE
Add Panasonic Light Tower LSSQ0342

### DIFF
--- a/VCR/Panasonic/Panasonic_Light_Tower_LSSQ0342.ir
+++ b/VCR/Panasonic/Panasonic_Light_Tower_LSSQ0342.ir
@@ -208,4 +208,3 @@ protocol: NEC
 address: 40 00 00 00
 command: 1E 00 00 00
 #
-

--- a/VCR/Panasonic/Panasonic_Light_Tower_LSSQ0342.ir
+++ b/VCR/Panasonic/Panasonic_Light_Tower_LSSQ0342.ir
@@ -1,0 +1,211 @@
+Filetype: IR signals file
+Version: 1
+#
+# Panasonic Omnivision VCR "Light Tower" LSSQ0342
+# only Functiosn not Possible/Cant Capture are TV, VCR Sat modes. as this doubles as a Universal Remote. |ADD/DLT| button captured but did nothing on Playback of Signal. Removed from File. 
+# 
+name: Play
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: A0 00 00 00
+# 
+name: Rewind
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 20 00 00 00
+# 
+name: Fast Forward
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 30 00 00 00
+# 
+name: Stop
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 00 00 00 00
+#
+name: Record
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 80 00 00 00
+# 
+name: Power
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: D0 03 00 00
+# 
+name: VCR/TV
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 60 03 00 00
+# 
+name: Action
+type: parsed
+protocol: Kaseikyo
+address: 91 02 20 01
+command: 60 01 00 00
+# 
+name: Input
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 03
+command: 00 00 00 00
+# 
+name: Prog
+type: parsed
+protocol: Kaseikyo
+address: 91 02 20 00
+command: 10 00 00 00
+# 
+name: Eject
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 10 00 00 00
+# 
+name: Pause
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 60 00 00 00
+# 
+name: Tracking +
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 40 03 00 00
+# 
+name: Tracking -
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 50 03 00 00
+# 
+name: 1
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 00 01 00 00
+# 
+name: 2
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 10 01 00 00
+# 
+name: 3
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 20 01 00 00
+# 
+name: 4
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 30 01 00 00
+# 
+name: 5
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 40 01 00 00
+# 
+name: 6
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 50 01 00 00
+# 
+name: 7
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 60 01 00 00
+# 
+name: 8
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 70 01 00 00
+# 
+name: 9
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 80 01 00 00
+# 
+name: 0
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 90 01 00 00
+# 
+name: 100
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 03
+command: 50 02 00 00
+# 
+name: Counter Reset
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 01
+command: 40 01 00 00
+# 
+name: Display
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 00
+command: 90 03 00 00
+# 
+name: Tape Position
+type: parsed
+protocol: Kaseikyo
+address: 95 02 20 00
+command: B0 02 00 00
+# 
+name: CM/Zero
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 03
+command: 80 03 00 00
+# 
+name: Speed
+type: parsed
+protocol: Kaseikyo
+address: 91 02 20 00
+command: A0 00 00 00
+# 
+name: Search
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 01
+command: 00 00 00 00
+# 
+name: SAP
+type: parsed
+protocol: Kaseikyo
+address: 90 02 20 03
+command: 60 02 00 00
+# 
+name: Vol +
+type: parsed
+protocol: NEC
+address: 40 00 00 00
+command: 1A 00 00 00
+# 
+name: Vol -
+type: parsed
+protocol: NEC
+address: 40 00 00 00
+command: 1E 00 00 00
+#
+


### PR DESCRIPTION
seems to be a common Model Panasonic Omnivision VCR, didn't see the Remote in the DB.  only 4 buttons not recorded/not Possible, "VCR" "TV" "SAT/Cable" modes & "Add/DLT" (this recorded by flipper, but did nothing on Playback.) Remote Functions as a Universal Remote as well however seems to be Secondary function as very spare set of supported Models TVs Cable boxes/satellite receivers in it's Manual. 