### PR TITLE
Add SMSL RC-8A

### DIFF
--- a/Audio_Receivers/SMSL/SMSL_RC-8A.ir
+++ b/Audio_Receivers/SMSL/SMSL_RC-8A.ir
@@ -15,7 +15,7 @@ protocol: NECext
 address: 12 34 00 00
 command: 0A F5 00 00
 #  
-name: Vol_down
+name: Vol_dn
 type: parsed
 protocol: NECext
 address: 12 34 00 00

--- a/Audio_Receivers/SMSL/SMSL_RC-8A.ir
+++ b/Audio_Receivers/SMSL/SMSL_RC-8A.ir
@@ -1,0 +1,64 @@
+Filetype: IR signals file
+Version: 1
+#
+# SMSL RC-8A
+#
+name: Power
+type: parsed
+protocol: NECext
+address: 12 34 00 00
+command: 01 FE 00 00
+# 
+name: Vol.up
+type: parsed
+protocol: NECext
+address: 12 34 00 00
+command: 0A F5 00 00
+#  
+name: Vol.down
+type: parsed
+protocol: NECext
+address: 12 34 00 00
+command: 0B F4 00 00
+# 
+name: Mute
+type: parsed
+protocol: NECext
+address: 12 34 00 00
+command: 09 F6 00 00
+# 
+name: Input
+type: parsed
+protocol: NECext
+address: 12 34 00 00
+command: 07 F8 00 00
+# 
+name: FN
+type: parsed
+protocol: NECext
+address: 12 34 00 00
+command: 08 F7 00 00
+# 
+name: Up
+type: parsed
+protocol: NECext
+address: 12 34 00 00
+command: 02 FD 00 00
+# 
+name: Down
+type: parsed
+protocol: NECext
+address: 12 34 00 00
+command: 06 F9 00 00
+# 
+name: Left
+type: parsed
+protocol: NECext
+address: 12 34 00 00
+command: 03 FC 00 00
+# 
+name: Right
+type: parsed
+protocol: NECext
+address: 12 34 00 00
+command: 05 FA 00 00

--- a/Audio_Receivers/SMSL/SMSL_RC-8A.ir
+++ b/Audio_Receivers/SMSL/SMSL_RC-8A.ir
@@ -9,13 +9,13 @@ protocol: NECext
 address: 12 34 00 00
 command: 01 FE 00 00
 # 
-name: Vol.up
+name: Vol_up
 type: parsed
 protocol: NECext
 address: 12 34 00 00
 command: 0A F5 00 00
 #  
-name: Vol.down
+name: Vol_down
 type: parsed
 protocol: NECext
 address: 12 34 00 00

--- a/Audio_Receivers/SMSL/SMSL_RC-8A.ir
+++ b/Audio_Receivers/SMSL/SMSL_RC-8A.ir
@@ -39,6 +39,12 @@ protocol: NECext
 address: 12 34 00 00
 command: 08 F7 00 00
 # 
+name: SELECT
+type: parsed
+protocol: NECext
+address: 12 34 00 00
+command: 04 FB 00 00
+# 
 name: Up
 type: parsed
 protocol: NECext


### PR DESCRIPTION
This works for SMSL bluetooth amplifier model AO100 and any other models using the same RC-8A remote.