### PR TITLE
Add DuneHD remote control

### DIFF
--- a/Multimedia/DuneHD/DuneHD.ir
+++ b/Multimedia/DuneHD/DuneHD.ir
@@ -1,0 +1,329 @@
+Filetype: IR signals file
+Version: 1
+#
+# DuneHD Remote Control
+#
+# Compatible with the players:
+#
+#   Kartina X
+#   Kartina S
+#   Kartina Micro HD
+#   Kartina Relax
+#   Dune HD Max
+#   Dune HD Duo
+#   Dune HD Base 3D
+#   Dune HD TV-101
+#   Dune HD TV-102
+#   Dune HD TV-301
+#   Dune HD TV-303D
+#   Dune HD Connect
+#   Dune HD Smart B1
+#   Dune HD Smart H1
+#   Dune HD Smart D1
+#   Dune HD Lite 53D
+#   Dune BD Prime 3.0
+#   Dune BD Prime
+#   Dune HD Base 3.0
+#   Dune HD Base 2.0
+#   Dune HD Base
+#   etc.
+#
+name: Power
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 43 BC 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 52 AD 00 00
+# 
+name: Vol_dn
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 53 AC 00 00
+# 
+name: Ch_prev
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 4B B4 00 00
+# 
+name: Ch_next
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 4C B3 00 00
+# 
+name: Mute
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 46 B9 00 00
+# 
+name: Enter
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 14 EB 00 00
+# 
+name: Up
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 15 EA 00 00
+# 
+name: Down
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 16 E9 00 00
+# 
+name: Right
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 18 E7 00 00
+# 
+name: Left
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 17 E8 00 00
+# 
+name: Info
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 50 AF 00 00
+# 
+name: PopupMenu
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 07 F8 00 00
+# 
+name: TopMenu
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 51 AE 00 00
+# 
+name: Return
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 04 FB 00 00
+# 
+name: Play
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 48 B7 00 00
+# 
+name: Pause
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 1E E1 00 00
+# 
+name: Prev
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 49 B6 00 00
+# 
+name: Next
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 1D E2 00 00
+# 
+name: Stop
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 19 E6 00 00
+# 
+name: Slow
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 1A E5 00 00
+# 
+name: Rew
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 1C E3 00 00
+# 
+name: Fwd
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 1B E4 00 00
+# 
+name: A_red
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 40 BF 00 00
+# 
+name: B_green
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 1F E0 00 00
+# 
+name: C_yellow
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 00 FF 00 00
+# 
+name: D_blue
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 41 BE 00 00
+# 
+name: Subtitle
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 54 AB 00 00
+# 
+name: Rotate
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 4D B2 00 00
+# 
+name: Audio
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 44 BB 00 00
+# 
+name: Rec
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 60 9F 00 00
+# 
+name: Dune
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 61 9E 00 00
+# 
+name: Url
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 62 9D 00 00
+# 
+name: Mode
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 45 BA 00 00
+# 
+name: Search
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 06 F9 00 00
+# 
+name: Zoom
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 02 FD 00 00
+# 
+name: Setup
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 4E B1 00 00
+# 
+name: 1
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 0B F4 00 00
+# 
+name: 2
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 0C F3 00 00
+# 
+name: 3
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 0D F2 00 00
+# 
+name: 4
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 0E F1 00 00
+# 
+name: 5
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 0F F0 00 00
+# 
+name: 6
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 01 FE 00 00
+# 
+name: 7
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 11 EE 00 00
+# 
+name: 8
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 12 ED 00 00
+# 
+name: 9
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 13 EC 00 00
+# 
+name: 0
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 0A F5 00 00
+# 
+name: Clear
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 05 FA 00 00
+# 
+name: Select
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 42 BD 00 00
+# 
+name: TV
+type: parsed
+protocol: NECext
+address: 00 BF 00 00
+command: 63 9C 00 00


### PR DESCRIPTION
Add DuneHD Remote Control

Compatible with the players:

Kartina X
Kartina S
Kartina Micro HD
Kartina Relax
Dune HD Max
Dune HD Duo
Dune HD Base 3D
Dune HD TV-101
Dune HD TV-102
Dune HD TV-301
Dune HD TV-303D
Dune HD Connect
Dune HD Smart B1
Dune HD Smart H1
Dune HD Smart D1
Dune HD Lite 53D
Dune BD Prime 3.0
Dune BD Prime
Dune HD Base 3.0
Dune HD Base 2.0
Dune HD Base

Captured from the original remote