### PR TITLE
Fan - Add Shark Flex Breeze

### DIFF
--- a/Fans/Shark/Shark_FlexBreeze-FA22X.ir
+++ b/Fans/Shark/Shark_FlexBreeze-FA22X.ir
@@ -1,40 +1,50 @@
 Filetype: IR signals file
 Version: 1
+#
+# Shark Flex Breeze FA22X Fan
+#
 name: Power
 type: parsed
 protocol: NEC
 address: 00 00 00 00
 command: 55 00 00 00
+#
 name: Sleep timer
 type: parsed
 protocol: NEC
 address: 00 00 00 00
 command: 13 00 00 00
+#
 name: Fan +
 type: parsed
 protocol: NEC
 address: 00 00 00 00
 command: 27 00 00 00
+#
 name: Fan -
 type: parsed
 protocol: NEC
 address: 00 00 00 00
 command: 4A 00 00 00
+#
 name: Oscillation +
 type: parsed
 protocol: NEC
 address: 00 00 00 00
 command: 59 00 00 00
+#
 name: Oscillation -
 type: parsed
 protocol: NEC
 address: 00 00 00 00
 command: 68 00 00 00
+#
 name: Left
 type: parsed
 protocol: NEC
 address: 00 00 00 00
 command: 1C 00 00 00
+#
 name: Right
 type: parsed
 protocol: NEC

--- a/Fans/Shark/Shark_FlexBreeze-FA22X.ir
+++ b/Fans/Shark/Shark_FlexBreeze-FA22X.ir
@@ -1,0 +1,42 @@
+Filetype: IR signals file
+Version: 1
+name: Power
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 55 00 00 00
+name: Sleep timer
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 13 00 00 00
+name: Fan +
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 27 00 00 00
+name: Fan -
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 4A 00 00 00
+name: Oscillation +
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 59 00 00 00
+name: Oscillation -
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 68 00 00 00
+name: Left
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 1C 00 00 00
+name: Right
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 34 00 00 00


### PR DESCRIPTION
I captured the codes from a  FA220UK, im assuming the remotes are the same internationally, so i have tentatively named the file `Shark_FlexBreeze-FA22X.ir` as the main diffrence between the UK, EU, and US version are the last digit(220 seems to be the European model, and 222 the US) and the last 2 letters being the plug type(UK, EU, the US one drops the letters)