### PR TITLE
Philips TV and Soundbar

### DIFF
--- a/SoundBars/Philips/Philips_TAB5105_79.ir
+++ b/SoundBars/Philips/Philips_TAB5105_79.ir
@@ -1,0 +1,80 @@
+Filetype: IR signals file
+Version: 1
+# 
+# These codes learned from remote for
+# Philips soundbar model TAB5105/79
+#
+# Codes read from remote with Flipper zero
+# 
+name: Power
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: C7 00 00 00
+# 
+name: Mute
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: 0D 00 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: 10 00 00 00
+# 
+name: Vol_dn
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: 11 00 00 00
+# 
+name: BT(Pair)
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: 69 00 00 00
+# 
+name: HDMI(ARC)
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: 87 00 00 00
+# 
+name: EQ
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: 51 00 00 00
+# 
+name: AUX
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: 6B 00 00 00
+# 
+name: Optical
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: 6C 00 00 00
+# 
+name: Next
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: 20 00 00 00
+# 
+name: Prev
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: 21 00 00 00
+# 
+name: Play
+type: parsed
+protocol: RC6
+address: 10 00 00 00
+command: 2C 00 00 00
+

--- a/TVs/Philips/Philips_50PUT6103_79.ir
+++ b/TVs/Philips/Philips_50PUT6103_79.ir
@@ -1,0 +1,278 @@
+Filetype: IR signals file
+Version: 1
+#
+# These codes learned from Philips remote
+# control model no 398GR08BEPHN0025JH packaged
+# with TV model 50PUT6103/79
+#
+# Codes read by Flipper Zero
+#
+name: Power
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 0C 00 00 00
+# 
+name: Mute
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 0D 00 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 10 00 00 00
+# 
+name: Vol_dn
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 11 00 00 00
+# 
+name: Home
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 54 00 00 00
+# 
+name: Back
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 0A 00 00 00
+# 
+name: Settings
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: BF 00 00 00
+# 
+name: OK
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 5C 00 00 00
+# 
+name: Up
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 58 00 00 00
+# 
+name: Down
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 59 00 00 00
+# 
+name: Left
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 5A 00 00 00
+# 
+name: Right
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 5B 00 00 00
+# 
+name: Info
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 0F 00 00 00
+# 
+name: Options
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 40 00 00 00
+# 
+name: Format
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: F5 00 00 00
+# 
+name: Ch_next
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 20 00 00 00
+# 
+name: Ch_prev
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 21 00 00 00
+# 
+name: Netflix
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 76 00 00 00
+# 
+name: Subtitle
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 4B 00 00 00
+# 
+name: Text
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 3C 00 00 00
+# 
+name: TV(Exit)
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 9F 00 00 00
+# 
+name: Smart_TV
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: BE 00 00 00
+# 
+name: Stop
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 31 00 00 00
+# 
+name: Pause
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 30 00 00 00
+# 
+name: Record
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 37 00 00 00
+# 
+name: RW
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 2B 00 00 00
+# 
+name: Play
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 2C 00 00 00
+# 
+name: FF
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 28 00 00 00
+# 
+name: TV_guide
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: CC 00 00 00
+# 
+name: List
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: D2 00 00 00
+# 
+name: Source
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 38 00 00 00
+# 
+name: Red
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 6D 00 00 00
+# 
+name: Green
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 6E 00 00 00
+# 
+name: Yellow
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 6F 00 00 00
+# 
+name: Blue
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 70 00 00 00
+# 
+name: 1
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 01 00 00 00
+# 
+name: 2
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 02 00 00 00
+# 
+name: 3
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 03 00 00 00
+# 
+name: 4
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 04 00 00 00
+# 
+name: 5
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 05 00 00 00
+# 
+name: 6
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 06 00 00 00
+# 
+name: 7
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 07 00 00 00
+# 
+name: 8
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 08 00 00 00
+# 
+name: 9
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 09 00 00 00
+# 
+name: 0
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 00 00 00 00


### PR DESCRIPTION
These codes learned from Philips remote
control model no 398GR08BEPHN0025JH packaged
with TV model 50PUT6103/79
Codes read by Flipper Zero
-=-=-
These codes learned from remote for
Philips soundbar model TAB5105/79
Codes read from remote with Flipper zero
