### PR TITLE
Added TCL 65C635K TV Remote

### DIFF
--- a/TVs/TCL/TCL_65C635K.ir
+++ b/TVs/TCL/TCL_65C635K.ir
@@ -1,6 +1,8 @@
 Filetype: IR signals file
 Version: 1
 # 
+# TCL 65C635K TV
+#
 name: Power
 type: parsed
 protocol: RCA

--- a/TVs/TCL/TCL_65C635K.ir
+++ b/TVs/TCL/TCL_65C635K.ir
@@ -1,0 +1,272 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: Power
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 54 00 00 00
+# 
+name: Mute
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: FC 00 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: F4 00 00 00
+# 
+name: Vol_dw
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 74 00 00 00
+# 
+name: Home
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 10 00 00 00
+# 
+name: Ok
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 2F 00 00 00
+# 
+name: Back
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: E4 00 00 00
+# 
+name: Up
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 9A 00 00 00
+# 
+name: Down
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 1A 00 00 00
+# 
+name: Left
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 6A 00 00 00
+# 
+name: Right
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: EA 00 00 00
+# 
+name: Menu
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 37 00 00 00
+# 
+name: Source
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: C5 00 00 00
+# 
+name: Settings
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: F3 00 00 00
+# 
+name: Ch_up
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: B4 00 00 00
+# 
+name: Ch_dw
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 34 00 00 00
+# 
+name: Info
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 3C 00 00 00
+# 
+name: List
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 86 00 00 00
+# 
+name: 0
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 0C 00 00 00
+# 
+name: 1
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 8C 00 00 00
+# 
+name: 2
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 4C 00 00 00
+# 
+name: 3
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: CC 00 00 00
+# 
+name: 4
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 2C 00 00 00
+# 
+name: 5
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: AC 00 00 00
+# 
+name: 6
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 6C 00 00 00
+# 
+name: 7
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: EC 00 00 00
+# 
+name: 8
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 1C 00 00 00
+# 
+name: 9
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 9C 00 00 00
+# 
+name: Exit
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 60 00 00 00
+# 
+name: Language
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: FB 00 00 00
+# 
+name: Guide
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 58 00 00 00
+# 
+name: Text
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 78 00 00 00
+# 
+name: Subtitles
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 01 00 00 00
+# 
+name: Red
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 00 00 00 00
+# 
+name: Green
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 17 00 00 00
+# 
+name: Yellow
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 27 00 00 00
+# 
+name: Blue
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 1B 00 00 00
+# 
+name: Rewind
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: B8 00 00 00
+# 
+name: Pause
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 98 00 00 00
+# 
+name: Play
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: A8 00 00 00
+# 
+name: Forward
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 38 00 00 00
+# 
+name: Zoom
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 09 00 00 00
+# 
+name: Record
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: F8 00 00 00
+# 
+name: Freeview
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: 57 00 00 00
+# 
+name: Netflix
+type: parsed
+protocol: RCA
+address: 0F 00 00 00
+command: F7 00 00 00


### PR DESCRIPTION
Added an additional TV remote for the TCL 65C635K.
All button included sorted by common usage/convenience.