### PR TITLE
Added Rytaki US HDMI501-8K-H HDMI Switch

### DIFF
--- a/Multimedia/Rytaki/Rytaki_US_HDMI501-8K-H.ir
+++ b/Multimedia/Rytaki/Rytaki_US_HDMI501-8K-H.ir
@@ -1,0 +1,52 @@
+Filetype: IR signals file
+Version: 1
+#
+# Rytaki US HDMI501-8K-H (5x1 powered HDMI Switch)
+# 
+name: Power
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 45 00 00 00
+# 
+name: 1
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 07 00 00 00
+# 
+name: 2
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 09 00 00 00
+# 
+name: 3
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 16 00 00 00
+# 
+name: 4
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 0D 00 00 00
+# 
+name: 5
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 18 00 00 00
+# 
+name: Back
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 08 00 00 00
+# 
+name: Next
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 5A 00 00 00


### PR DESCRIPTION
This adds captured/parsed signals for the Rytaki US HDMI501-8K-H powered HDMI 5x1 switch (e.g. https://www.amazon.com/dp/B0CC4LGH2C).