### PR TITLE
Added Gogen TVH24P266T

### DIFF
--- a/TVs/Gogen/Gogen_TVH24P266T.ir
+++ b/TVs/Gogen/Gogen_TVH24P266T.ir
@@ -122,4 +122,3 @@ type: parsed
 protocol: RC5
 address: 01 00 00 00
 command: 34 00 00 00
-

--- a/TVs/Gogen/Gogen_TVH24P266T.ir
+++ b/TVs/Gogen/Gogen_TVH24P266T.ir
@@ -1,0 +1,125 @@
+Filetype: IR signals file
+Version: 1
+#
+# Gogen TVH24P266T
+# 
+name: Power
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 0C 00 00 00
+# 
+name: Source
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 38 00 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 10 00 00 00
+# 
+name: Vol_dn
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 11 00 00 00
+# 
+name: Ch_next
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 20 00 00 00
+# 
+name: Ch_prev
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 21 00 00 00
+# 
+name: Mute
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 0D 00 00 00
+# 
+name: OK
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 35 00 00 00
+# 
+name: Left
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 15 00 00 00
+# 
+name: Right
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 16 00 00 00
+# 
+name: Up
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 14 00 00 00
+# 
+name: Down
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 13 00 00 00
+# 
+name: Menu
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 30 00 00 00
+# 
+name: Q_Menu
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 2B 00 00 00
+# 
+name: Back
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 0A 00 00 00
+# 
+name: Exit
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 25 00 00 00
+# 
+name: Red
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 37 00 00 00
+# 
+name: Green
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 36 00 00 00
+# 
+name: Yellow
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 32 00 00 00
+# 
+name: Blue
+type: parsed
+protocol: RC5
+address: 01 00 00 00
+command: 34 00 00 00
+


### PR DESCRIPTION
New TV added.

- TVs/Gogen/Gogen_TVH24P266T.ir : Added a new file with IR signal data for TV Gogen TVH24P266T.