### PR TITLE
Remote for  LG MKJ33981404

### DIFF
--- a/TVs/LG/LG_MKJ33981404.ir
+++ b/TVs/LG/LG_MKJ33981404.ir
@@ -33,25 +33,25 @@ protocol: NEC
 address: 04 00 00 00
 command: 44 00 00 00
 # 
-name: Pr_next_up
+name: Ch_up
 type: parsed
 protocol: NEC
 address: 04 00 00 00
 command: 00 00 00 00
 # 
-name: Pr_prev_down
+name: Ch_down
 type: parsed
 protocol: NEC
 address: 04 00 00 00
 command: 01 00 00 00
 # 
-name: Vol_up_right
+name: Vol_up
 type: parsed
 protocol: NEC
 address: 04 00 00 00
 command: 02 00 00 00
 # 
-name: Vol_down_left
+name: Vol_down
 type: parsed
 protocol: NEC
 address: 04 00 00 00

--- a/TVs/LG/LG_MKJ33981404.ir
+++ b/TVs/LG/LG_MKJ33981404.ir
@@ -33,13 +33,13 @@ protocol: NEC
 address: 04 00 00 00
 command: 44 00 00 00
 # 
-name: Ch_up
+name: Ch_next
 type: parsed
 protocol: NEC
 address: 04 00 00 00
 command: 00 00 00 00
 # 
-name: Ch_down
+name: Ch_prev
 type: parsed
 protocol: NEC
 address: 04 00 00 00
@@ -51,7 +51,7 @@ protocol: NEC
 address: 04 00 00 00
 command: 02 00 00 00
 # 
-name: Vol_down
+name: Vol_dn
 type: parsed
 protocol: NEC
 address: 04 00 00 00

--- a/TVs/LG/LG_MKJ33981404.ir
+++ b/TVs/LG/LG_MKJ33981404.ir
@@ -1,0 +1,58 @@
+Filetype: IR signals file
+Version: 1
+# LG MKJ33981404, also fits for following models:
+# LG 21FG5RL, LG 21FJ8RL, LG 21FK2RG, LG 21FU4R-L3, LG 21FU4RL, LG 21FU4RLX, LG 21FU6-L4, LG 21FU6PL, LG 21FU6R-L4, LG 21FU6RG, 
+# LG 21FU6RL, LG 21FU6RL-Z4, LG 21FU6RLX, LG 21FU6T, LG 21FU6TL, LG 21SA1RL, LG 21SB1RL, LG 21SB1RG-Z4
+name: Power
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 08 00 00 00
+# 
+name: Source
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 0B 00 00 00
+# 
+name: Mute
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 09 00 00 00
+# 
+name: Menu
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 43 00 00 00
+# 
+name: Ok
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 44 00 00 00
+# 
+name: Pr_next_up
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 00 00 00 00
+# 
+name: Pr_prev_down
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 01 00 00 00
+# 
+name: Vol_up_right
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 02 00 00 00
+# 
+name: Vol_down_left
+type: parsed
+protocol: NEC
+address: 04 00 00 00
+command: 03 00 00 00


### PR DESCRIPTION
Also fits to the following models:
- LG 21FG5RL
- LG 21FJ8RL
- LG 21FK2RG
- LG 21FU4R-L3
- LG 21FU4RL
- LG 21FU4RLX
- LG 21FU6-L4
- LG 21FU6PL
- LG 21FU6R-L4
- LG 21FU6RG
- LG 21FU6RL
- LG 21FU6RL-Z4
- LG 21FU6RLX
- LG 21FU6T
- LG 21FU6TL
- LG 21SA1RL
- LG 21SB1RL
- LG 21SB1RG-Z4

![image](https://github.com/user-attachments/assets/dff48b2b-d529-4534-9f34-919b4082393e)

Product page:
https://pulthouse.com.ua/pulty-du-televizor/lg-mkj33981404/