### PR TITLE
Add MCM Custom Audio Volume Control

### DIFF
--- a/Audio_and_Video_Receivers/MCM_Custom_Audio/MCM_Volume_Control_50-8394.ir
+++ b/Audio_and_Video_Receivers/MCM_Custom_Audio/MCM_Volume_Control_50-8394.ir
@@ -1,0 +1,22 @@
+Filetype: IR signals file
+Version: 1
+#
+# For MCM Custom Audio 50-8394 IR Volume Control
+# 
+name: Mute
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 47 00 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 0D 00 00 00
+# 
+name: Vol_dn
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 16 00 00 00


### PR DESCRIPTION
This adds support for the MCM Custom Audio Volume Control, available from https://www.newark.com/mcm-custom-audio/50-8394/line-level-volume-control-rohs/dp/79X4195. The only control on the remote are mute, volume up and volume down.

Note: the datasheet on that page claims to have the IR codes, but they don't work, and the ones in this PR are taken from the flipper learning a working remote.