### PR TITLE
Add rocketfish hdmi switch RF-G1501

### DIFF
--- a/Miscellaneous/RocketFish/RF_G1501.ir
+++ b/Miscellaneous/RocketFish/RF_G1501.ir
@@ -1,0 +1,32 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: Power
+type: parsed
+protocol: NECext
+address: 82 FF 00 00
+command: 12 ED 00 00
+# 
+name: Input 1
+type: parsed
+protocol: NECext
+address: 82 FF 00 00
+command: 05 FA 00 00
+# 
+name: Input 2
+type: parsed
+protocol: NECext
+address: 82 FF 00 00
+command: 07 F8 00 00
+# 
+name: Input 3
+type: parsed
+protocol: NECext
+address: 82 FF 00 00
+command: 1B E4 00 00
+# 
+name: Input 4
+type: parsed
+protocol: NECext
+address: 82 FF 00 00
+command: 09 F6 00 00


### PR DESCRIPTION
Manual: https://files.bbystatic.com/4G8hdhTB%2F56AOz0EqiDKhw%3D%3D/RF-G1501_RF-G1501-C_20-0446_QSG_V8_EN_Final_lr.pdf

Input source buttons don't follow the naming scheme due to it not being listed in that scheme