### PR TITLE
Adding Legamaster_DIS-9800 file to Touchscreen Displays

### DIFF
--- a/Touchscreen_Displays/Legamaster/Legamaster_DIS-9800.ir
+++ b/Touchscreen_Displays/Legamaster/Legamaster_DIS-9800.ir
@@ -1,0 +1,100 @@
+Filetype: IR signals file
+Version: 1
+#
+# Legamaster Discover 9800 or Legamaster DIS-9800
+#
+name: Power
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 0A F5 00 00
+# 
+name: Source
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 41 BE 00 00
+# 
+name: Freeze
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 0C F3 00 00
+# 
+name: Mute
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 0F F0 00 00
+# 
+name: Home
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 1A E5 00 00
+# 
+name: Menu
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 42 BD 00 00
+# 
+name: Back
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 40 BF 00 00
+#
+name: Ok
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 0D F2 00 00
+#
+name: Up
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 0B F4 00 00
+# 
+name: Down
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 0E F1 00 00
+# 
+name: Left
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 10 EF 00 00
+# 
+name: Right
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 11 EE 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 15 EA 00 00
+# 
+name: Vol_down
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 1C E3 00 00
+# 
+name: Hdmi
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 37 C8 00 00
+# 
+name: Ops
+type: parsed
+protocol: NECext
+address: 40 40 00 00
+command: 33 CC 00 00


### PR DESCRIPTION
This remote file is for the Touchscreen Display Legamaster DIS-9800 or Legamaster Discover-9800. I don't know if it is also compatible with the next version (Discover-2 or DIS-9810), but I assume it should also work with that one.