### PR TITLE
Add additional paths to linter

### DIFF
--- a/.fff-ir-lint.json
+++ b/.fff-ir-lint.json
@@ -64,7 +64,7 @@
           "$group:power-off"
         ]
       },
-      "Audio_Receivers/*,SoundBars/*,Speakers/*": {
+      "Audio_and_Video_Receivers/*,SoundBars/*,Speakers/*,Blu-Ray/*,Cable_Boxes/*,CD_Players/*,DVB-T/*,DVD_Players/*,Laserdisc/*,MiniDisc/*,Multimedia/*,TV_Tuner/*,VCR/*": {
         "Power": [
           "$group:power-toggle"
         ],


### PR DESCRIPTION
- The AVR path had a typo, meaning it wasn't being checked
- A number of other similarly-behaving paths didn't have lints, this added those directories