### PR TITLE
most buttons for the SLV-D281P DVD/VCR combo unit

### DIFF
--- a/VCR/Sony/Sony_SLV-D281P.ir
+++ b/VCR/Sony/Sony_SLV-D281P.ir
@@ -1,6 +1,8 @@
 Filetype: IR signals file
 Version: 1
-# 
+#
+# Sony SLV-D281P
+#
 name: Power
 type: parsed
 protocol: SIRC20

--- a/VCR/Sony/Sony_slvd281p.ir
+++ b/VCR/Sony/Sony_slvd281p.ir
@@ -1,0 +1,122 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: Power
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 15 00 00 00
+# 
+name: Dvd
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 6A 00 00 00
+# 
+name: Video
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 69 00 00 00
+# 
+name: Eject
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 16 00 00 00
+# 
+name: Play
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 1A 00 00 00
+# 
+name: Pause
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 19 00 00 00
+# 
+name: Stop
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 18 00 00 00
+# 
+name: Enter
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 0B 00 00 00
+# 
+name: Left
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 62 00 00 00
+# 
+name: Right
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 61 00 00 00
+# 
+name: Up
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 42 00 00 00
+# 
+name: Down
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 43 00 00 00
+# 
+name: Display
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 5A 00 00 00
+# 
+name: Top_menu
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 22 00 00 00
+# 
+name: Menu
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 23 00 00 00
+# 
+name: Setup
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 4D 00 00 00
+# 
+name: Input_select
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 4F 00 00 00
+# 
+name: Record
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 1D 00 00 00
+# 
+name: Rewind
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 1B 00 00 00
+# 
+name: Fast_forward
+type: parsed
+protocol: SIRC20
+address: 7A 0A 00 00
+command: 1C 00 00 00


### PR DESCRIPTION
most buttons for the SLV-D281P DVD/VCR combo unit, didnt get every button on the remote as most are useless for just watching DVDs, VHS Tapes, and using the 2 composite inputs on the unit