### PR TITLE
Create Sanyo UR77EC2703-3.ir

### DIFF
--- a/TVs/Sanyo/Sanyo UR77EC2703-3.ir
+++ b/TVs/Sanyo/Sanyo UR77EC2703-3.ir
@@ -1,0 +1,196 @@
+Filetype: IR signals file
+Version: 1
+# 
+# Sanyo HT28745 TV
+#
+name: Power
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 12 00 00 00
+# 
+name: Input
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 13 00 00 00
+# 
+name: Pix Shape
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 57 00 00 00
+# 
+name: Mute
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 18 00 00 00
+# 
+name: Vol Up
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 0E 00 00 00
+# 
+name: Vol Down
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 0F 00 00 00
+# 
+name: Ch Up
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 0A 00 00 00
+# 
+name: Ch Down
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 0B 00 00 00
+# 
+name: Info
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 0C 00 00 00
+# 
+name: Tuner
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 55 00 00 00
+# 
+name: Sleep
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 0D 00 00 00
+# 
+name: Recall
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 19 00 00 00
+# 
+name: Caption
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 11 00 00 00
+# 
+name: Audio
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 1A 00 00 00
+# 
+name: 1
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 01 00 00 00
+# 
+name: 2
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 02 00 00 00
+# 
+name: 3
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 03 00 00 00
+# 
+name: 4
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 04 00 00 00
+# 
+name: 5
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 05 00 00 00
+# 
+name: 6
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 06 00 00 00
+# 
+name: 7
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 07 00 00 00
+# 
+name: 8
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 08 00 00 00
+# 
+name: 9
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 09 00 00 00
+# 
+name: 0
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 00 00 00 00
+# 
+name: Menu
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 17 00 00 00
+# 
+name: Up
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 4E 00 00 00
+# 
+name: Down
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 4F 00 00 00
+# 
+name: Left
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 1F 00 00 00
+# 
+name: Right
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 1E 00 00 00
+# 
+name: Enter
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 54 00 00 00
+# 
+name: Exit
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 53 00 00 00
+# 
+name: Reset
+type: parsed
+protocol: NEC
+address: 38 00 00 00
+command: 1C 00 00 00


### PR DESCRIPTION
OEM Remote for the Sanyo HT28745 TV with buttons unique to the SD/HD dual tuner configuration of this set.