### PR TITLE
Add missing button for Hobot 2S

### DIFF
--- a/Window_cleaners/HOBOT/Hobot_2S.ir
+++ b/Window_cleaners/HOBOT/Hobot_2S.ir
@@ -5,7 +5,7 @@ Version: 1
 # 
 # HOBOT-2S 
 # 
-name: SPRAY
+name: SPRAY_TOGGLE
 type: parsed
 protocol: NECext
 address: C5 1F 00 00
@@ -58,6 +58,12 @@ type: parsed
 protocol: NECext
 address: C5 1F 00 00
 command: 1E E1 00 00
+#
+name: SPRAY_ONCE
+type: parsed
+protocol: NECext
+address: C5 1F 00 00
+command: 0E F1 00 00
 # 
 name: STOP
 type: parsed


### PR DESCRIPTION
Added SPRAY_ONCE button and renamed SPRAY to SPRAY_TOGGLE for Hobot 2S remote.