### PR TITLE
Create DuraBrand DU-1301

### DIFF
--- a/TVs/DuraBrand DU-1301
+++ b/TVs/DuraBrand DU-1301
@@ -1,0 +1,120 @@
+Filetype: IR signals file
+Version: 1
+#
+name: Power
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 0F F0 00 00
+#
+name: Vol_up
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 0C F3 00 00
+#
+name: Vol_dn
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 0D F2 00 00
+#
+name: Ch_next
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 0A F5 00 00
+#
+name: Ch_prev
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 0B F4 00 00
+#
+name: Mute
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 0E F1 00 00
+#
+name: 1
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 00 FF 00 00
+#
+name: 2
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 01 FE 00 00
+#
+name: 3
+type: parsedFiletype: IR signals file
+Version: 1
+#
+name: Power
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 0F F0 00 00
+#
+name: Vol_up
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 0C F3 00 00
+#
+name: Vol_dn
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 0D F2 00 00
+#
+name: Ch_next
+protocol: NECext
+address: 86 05 00 00
+command: 02 FD 00 00
+#
+name: 4
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 03 FC 00 00
+#
+name: 5
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 04 FB 00 00
+#
+name: 6
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 05 FA 00 00
+#
+name: 7
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 06 F9 00 00
+#
+name: 8
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 07 F8 00 00
+#
+name: 9
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 08 F7 00 00
+#
+name: 0
+type: parsed
+protocol: NECext
+address: 86 05 00 00
+command: 09 F6 00 00
+#


### PR DESCRIPTION
NEC protocol, also applies to other DuraBrand televisions of its era. Includes power/vol/ch/mute plus numbers 0-9