### PR TITLE
Create IR signals file for Lexus GX470 DVD 2008

### DIFF
--- a/Car_Multimedia/DVD_Players/Lexus/Lexus_GX470_DVD_2008.ir
+++ b/Car_Multimedia/DVD_Players/Lexus/Lexus_GX470_DVD_2008.ir
@@ -1,0 +1,158 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: DVD
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 18 E7 00 00
+# 
+name: Video
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 12 ED 00 00
+# 
+name: Option
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 11 EE 00 00
+# 
+name: Off
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 0C F3 00 00
+# 
+name: Play_Pause
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 1E E1 00 00
+# 
+name: Rewind
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 1C E3 00 00
+# 
+name: Stop
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 1D E2 00 00
+# 
+name: Fast_Forward
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 1F E0 00 00
+# 
+name: Up
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 20 DF 00 00
+# 
+name: Right
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 23 DC 00 00
+# 
+name: Down
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 21 DE 00 00
+# 
+name: Left
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 22 DD 00 00
+# 
+name: Enter
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 28 D7 00 00
+# 
+name: Track_Up
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 0A F5 00 00
+# 
+name: Chapter_Down
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 0B F4 00 00
+# 
+name: Folder_Up
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 4E B1 00 00
+# 
+name: Folder_Down
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 4F B0 00 00
+# 
+name: Top_Menu
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 1A E5 00 00
+# 
+name: Menu
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 19 E6 00 00
+# 
+name: Setup
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 41 BE 00 00
+# 
+name: Search
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 45 BA 00 00
+# 
+name: Subtitle
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 42 BD 00 00
+# 
+name: Audio
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 43 BC 00 00
+# 
+name: Angle
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 44 BB 00 00
+# 
+name: Size
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 16 E9 00 00
+# 
+name: Display
+type: parsed
+protocol: NECext
+address: 80 E7 00 00
+command: 15 EA 00 00


### PR DESCRIPTION
Added IR signals file for Lexus GX470 DVD 2008. Probably works for 2007-2009 but I only have one to try it out on.