### PR TITLE
Added streaming device AppleTV 4K 2gen 2021

### DIFF
--- a/Streaming_Devices/Apple/Apple_TV_4K_Gen2.ir
+++ b/Streaming_Devices/Apple/Apple_TV_4K_Gen2.ir
@@ -1,0 +1,71 @@
+Filetype: IR signals file
+Version: 1
+#
+# Tested on:
+# Apple TV 4K (2nd Gen, 2021)
+# Model: A2169
+# Remote Control Model: A2540 (Siri Remote)
+#
+# Note: I was not able to find codes for these buttons:
+#       Vol_up, Vol_dn, Mute, Siri_mic
+#
+#
+name: Power_off
+type: parsed
+protocol: NECext
+address: E5 87 00 00
+command: 2A FE 00 00
+#
+name: Power_on
+type: parsed
+protocol: NECext
+address: E5 87 00 00
+command: 2C FE 00 00
+#
+name: TV
+type: parsed
+protocol: NECext
+address: E5 87 00 00
+command: 40 FE 00 00
+#
+name: Ok
+type: parsed
+protocol: NECext
+address: EE 87 00 00
+command: 5C 8C 00 00
+#
+name: Up
+type: parsed
+protocol: NECext
+address: EE 87 00 00
+command: 0A 8C 00 00
+#
+name: Down
+type: parsed
+protocol: NECext
+address: EE 87 00 00
+command: 0C 8C 00 00
+#
+name: Left
+type: parsed
+protocol: NECext
+address: EE 87 00 00
+command: 09 8C 00 00
+#
+name: Right
+type: parsed
+protocol: NECext
+address: EE 87 00 00
+command: 06 8C 00 00
+#
+name: Back
+type: parsed
+protocol: NECext
+address: EE 87 00 00
+command: 03 8C 00 00
+#
+name: Play_pause
+type: parsed
+protocol: NECext
+address: EE 87 00 00
+command: 5F 8C 00 00


### PR DESCRIPTION
I searched for these codes for a very long time – I couldn't find them in any database. I finally managed to sort them out using several hw hacking devices and different software. The most problematic was the "TV" button (also known as "HOME" that can be changed in AppleTV Settings). All button names correspond to the official names from Apple.

There are still 4 buttons, I was not able to find codes for: Vol_up, Vol_dn, Mute, Siri_mic