### PR TITLE
Add basic remote for SEG Malta TV.

### DIFF
--- a/TVs/SEG/SEG_MALTA.ir
+++ b/TVs/SEG/SEG_MALTA.ir
@@ -2,8 +2,10 @@ Filetype: IR signals file
 Version: 1
 #
 # SEG Malta TV
-# Note: Power key only turns the TV off, use Ch_prev/Ch_next or number
-# keys to turn on the TV.
+#
+# Note: Power key only turns the TV off
+#       Use Ch_prev/Ch_next or number
+#       keys to turn on the TV.
 #
 name: Ch_prev
 type: parsed
@@ -35,7 +37,7 @@ protocol: RC5
 address: 00 00 00 00
 command: 10 00 00 00
 #
-name: Power
+name: Power_Off
 type: parsed
 protocol: RC5
 address: 00 00 00 00


### PR DESCRIPTION
Adding remote codes for flatscreen TV SEG Malta of 2006 vintage. Allows manipulating basic controls and navigating menus.

Successfully used this to disable "child lock", which disables all physical buttons on the TV and renders it inoperable, unless one has a remote (I didn't).