### PR TITLE
Add Philips TV 40PFL6533/F7 D

### DIFF
--- a/TVs/Philips/Philips_40PFL6533_F7D.ir
+++ b/TVs/Philips/Philips_40PFL6533_F7D.ir
@@ -1,0 +1,136 @@
+Filetype: IR signals file
+Version: 1
+#
+# Brand: Philips
+# Device Model: 40PFL6533/F7 D
+# Device Type: TV
+# Link: https://www.usa.philips.com/c-p/40PFL6533_F7/roku-tv-6000-series-led-lcd-tv
+# Description: Philips Roku 6500 Series 40 in FHD TV
+# Contributor: Kaya Arro
+#
+name: Power
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 17 E8 00 00
+#
+name: Exit
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 66 99 00 00
+#
+name: Menu
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 03 FC 00 00
+#
+name: Ok
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 2A D5 00 00
+#
+name: Up
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 19 E6 00 00
+#
+name: Down
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 33 CC 00 00
+#
+name: Left
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 1E E1 00 00
+#
+name: Right
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 2D D2 00 00
+#
+name: Vol_up
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 0F F0 00 00
+#
+name: Vol_dn
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 10 EF 00 00
+#
+name: Mute
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 20 DF 00 00
+#
+name: Instant replay
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 78 87 00 00
+#
+name: Sleep
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 62 9D 00 00
+#
+name: Options
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 61 9E 00 00
+#
+name: Play_pause
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 4C B3 00 00
+#
+name: Prev
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 34 CB 00 00
+#
+name: Next
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 55 AA 00 00
+#
+name: Netflix
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 52 AD 00 00
+#
+name: Disney
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 0C F3 00 00
+#
+name: Apple
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 77 88 00 00
+#
+name: Prime
+type: parsed
+protocol: NECext
+address: EA C7 00 00
+command: 4B B4 00 00
+#


### PR DESCRIPTION
Brand: Philips
Device Model: 40PFL6533/F7 D
Device Type: TV
Link: https://www.usa.philips.com/c-p/40PFL6533_F7/roku-tv-6000-series-led-lcd-tv
Description: Philips Roku 6500 Series 40 in FHD TV