### PR TITLE
Add LG DVX7900 remote ir

### DIFF
--- a/VCR/LG/LG DVX7900.ir
+++ b/VCR/LG/LG DVX7900.ir
@@ -1,7 +1,8 @@
 Filetype: IR signals file
 Version: 1
 # 
-# LG VCR Remote model: 6711R1P073B
+# LG DVX7900 VCR / DVD Player
+# Remote model: 6711R1P073B
 #
 name: POWER
 type: parsed


### PR DESCRIPTION
Hello,

I've scan the remote of the LG DVX7900.
It's a DVDplayer/VCRplayer, i've put the file on the VCR folder.

