### PR TITLE
Add Hitachi CLE-1031 TV Remote

### DIFF
--- a/TVs/Hitachi/Hitachi_CLE-1031.ir
+++ b/TVs/Hitachi/Hitachi_CLE-1031.ir
@@ -1,0 +1,275 @@
+Filetype: IR signals file
+Version: 1
+#
+# Hitachi CLE-1031 TV remote
+# Designed for use with Hitachi TVs: 32FHDSM6 40FHDSM8 50UHDSM8 55UHDSM8  
+#
+name: Power
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 12 00 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 1A 00 00 00
+# 
+name: Vol_dn
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 1E 00 00 00
+# 
+name: Mute
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 10 00 00 00
+# 
+name: Ch_next
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 1B 00 00 00
+# 
+name: Ch_prev
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 1F 00 00 00
+# 
+name: Ok
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 0A 00 00 00
+# 
+name: Up
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 19 00 00 00
+# 
+name: Down
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 1D 00 00 00
+# 
+name: Left
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 46 00 00 00
+# 
+name: Right
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 47 00 00 00
+# 
+name: Menu
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 49 00 00 00
+# 
+name: Back
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 40 00 00 00
+# 
+name: Play
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 57 00 00 00
+# 
+name: Pause
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 48 00 00 00
+# 
+name: Stop
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 54 00 00 00
+# 
+name: Next
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 56 00 00 00
+# 
+name: Prev
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 59 00 00 00
+# 
+name: FF
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 4E 00 00 00
+# 
+name: Rew
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 4F 00 00 00
+# 
+name: Input
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 14 00 00 00
+# 
+name: Exit
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 44 00 00 00
+# 
+name: Record
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 53 00 00 00
+# 
+name: Info
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 16 00 00 00
+# 
+name: Audio Lang
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 1C 00 00 00
+# 
+name: Teletext
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 15 00 00 00
+# 
+name: 1
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 01 00 00 00
+# 
+name: 2
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 02 00 00 00
+# 
+name: 3
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 03 00 00 00
+# 
+name: 4
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 04 00 00 00
+# 
+name: 5
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 05 00 00 00
+# 
+name: 6
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 06 00 00 00
+# 
+name: 7
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 07 00 00 00
+# 
+name: 8
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 08 00 00 00
+# 
+name: 9
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 09 00 00 00
+# 
+name: 0
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 00 00 00 00
+# 
+name: Settings
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 0F 00 00 00
+# 
+name: Netflix
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 58 00 00 00
+# 
+name: YouTube
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 55 00 00 00
+# 
+name: Red
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 4A 00 00 00
+# 
+name: Green
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 4B 00 00 00
+# 
+name: Yellow
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 4C 00 00 00
+# 
+name: Blue
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 4D 00 00 00
+# 
+name: EPG
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 0B 00 00 00
+# 
+name: Ch_list
+type: parsed
+protocol: NEC
+address: 50 00 00 00
+command: 18 00 00 00


### PR DESCRIPTION
Hitachi CLE-1031 TV remote
Designed for use with Hitachi TVs: 32FHDSM6 40FHDSM8 50UHDSM8 55UHDSM8