### PR TITLE
Add Magnavox CD130MW8 TV/DVD combo

### DIFF
--- a/TVs/Magnavox/MAGNAVOX_CD130MW8.ir
+++ b/TVs/Magnavox/MAGNAVOX_CD130MW8.ir
@@ -1,0 +1,256 @@
+Filetype: IR signals file
+Version: 1
+#
+# Magnavox CD130MW8 TV/DVD combo
+# 
+name: Power
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: E0 1F 00 00
+# 
+name: Picture_sleep
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: C9 36 00 00
+# 
+name: Select
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: CD 32 00 00
+# 
+name: Open_close
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 44 BB 00 00
+# 
+name: Ch_next
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: D0 2F 00 00
+# 
+name: Ch_prev
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: C8 37 00 00
+# 
+name: 1
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: DF 20 00 00
+# 
+name: 2
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: E1 1E 00 00
+# 
+name: 3
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: E2 1D 00 00
+# 
+name: 4
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: E3 1C 00 00
+# 
+name: 5
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: E4 1B 00 00
+# 
+name: 6
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: E5 1A 00 00
+# 
+name: 7
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: E6 19 00 00
+# 
+name: 8
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: E7 18 00 00
+# 
+name: 9
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: E8 17 00 00
+# 
+name: 0
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: E9 16 00 00
+# 
+name: +10_+100
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: EC 13 00 00
+# 
+name: Vol_up
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: F0 0F 00 00
+# 
+name: Vol_dn
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: F1 0E 00 00
+# 
+name: Display
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: CF 30 00 00
+# 
+name: Set-up
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: EF 10 00 00
+# 
+name: Mute
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: F3 0C 00 00
+# 
+name: Speed
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: FB 04 00 00
+# 
+name: TV_VCR_audio
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 7B 84 00 00
+# 
+name: Prev
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 5D A2 00 00
+# 
+name: Next
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 5F A0 00 00
+# 
+name: Rew
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 52 AD 00 00
+# 
+name: Fwd
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 53 AC 00 00
+# 
+name: Play
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 5E A1 00 00
+# 
+name: Stop
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 60 9F 00 00
+#
+name: Slow_pause
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 5B A4 00 00
+# 
+name: Title
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 70 8F 00 00
+# 
+name: Disc_menu
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 71 8E 00 00
+# 
+name: Clear
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 58 A7 00 00
+# 
+name: Left
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: C7 38 00 00
+# 
+name: Up
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: F6 09 00 00
+# 
+name: Right
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: C6 39 00 00
+# 
+name: Down
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: F7 08 00 00
+# 
+name: Enter
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 72 8D 00 00
+# 
+name: Back
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 73 8C 00 00
+# 
+name: Mode
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 5C A3 00 00
+#
+name: Service_mode
+type: parsed
+protocol: NECext
+address: 87 22 00 00
+command: 7F 80 00 00


### PR DESCRIPTION
This adds the remote (and service mode button...though nothing else works in service mode) for a Magnavox CD130MW8 TV/DVD combo.