### PR TITLE
Add iLife V3/V5/V8/X5 IR codes

### DIFF
--- a/Vacuum_Cleaners/iLife/iLife_V3_V5_V8_X5.ir
+++ b/Vacuum_Cleaners/iLife/iLife_V3_V5_V8_X5.ir
@@ -1,6 +1,8 @@
 Filetype: IR signals file
 Version: 1
 #
+# iLife V3/V5/V8/X5 vacuum cleaners
+#
 name: Clean
 type: raw
 frequency: 38000


### PR DESCRIPTION
## Summary
- Adds IR signals file for iLife V3/V5/V8/X5 vacuum cleaners
- Includes commands: Clean, Home, Up, Down, Left, Right, Spiral, Edges