### PR TITLE
Continental Edison TV

### DIFF
--- a/TVs/ContinentalEdison/ContinentalEdison_CELD55SQLDV24B6.ir
+++ b/TVs/ContinentalEdison/ContinentalEdison_CELD55SQLDV24B6.ir
@@ -8,139 +8,139 @@ type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 15 EA 00 00
-
+#
 name: Vol_up
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 1B E4 00 00
-
+#
 name: Vol_dn
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 1A E5 00 00
-
+#
 name: Mute
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 16 E9 00 00
-
-name: Ch_up
+#
+name: Ch_next
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 19 E6 00 00
-
+#
 name: Up
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 0C F3 00 00
-
+#
 name: Down
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 0D F2 00 00
-
+#
 name: Right
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 0E F1 00 00
-
+#
 name: Left
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 0F F0 00 00
-
+#
 name: OK
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 11 EE 00 00
-
+#
 name: Input
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 12 ED 00 00
-
+#
 name: Satellite
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 18 E7 00 00
-
+#
 name: USB
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 4C B3 00 00
-
+#
 name: Settings
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 17 E8 00 00
-
+#
 name: App_Menu
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 25 DA 00 00
-
+#
 name: Account
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 21 DE 00 00
-
+#
 name: Home
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 42 BD 00 00
-
+#
 name: Exit
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 32 CD 00 00
-
+#
 name: Record
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 24 DB 00 00
-
+#
 name: Netflix
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 50 AF 00 00
-
+#
 name: YouTube
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 4F B0 00 00
-
+#
 name: Prime_Video
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 1C E3 00 00
-
+#
 name: Disney_Plus
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 1E E1 00 00
-
+#
 name: Pair_Remote
 type: parsed
 protocol: NECext

--- a/TVs/ContinentalEdison/ContinentalEdison_CELD55SQLDV24B6.ir
+++ b/TVs/ContinentalEdison/ContinentalEdison_CELD55SQLDV24B6.ir
@@ -1,21 +1,9 @@
 Filetype: IR signals file
 Version: 1
-
 #
-# Device: Continental Edison Smart TV
-# Model: CELD55SQLDV24B6
-# Protocol: NEC Extended (NECext)
-# IR Address: 00 7F 00 00
-#
-
-# Author: Kakuzu (original discovery and validation)
-# Contact: Telegram/Discord - @kakuzu_f0
-# Source: Personal reverse engineering with Flipper Zero
-
-#
-# ==================================================
-# SYSTEM POWER
-# ==================================================
+# Continental Edison CELD55SQLDV24B6 TV
+# Protocol: NECext
+# Address: 00 7F 00 00
 #
 name: Power
 type: parsed
@@ -23,11 +11,6 @@ protocol: NECext
 address: 00 7F 00 00
 command: 15 EA 00 00
 
-#
-# ==================================================
-# AUDIO CONTROL
-# ==================================================
-#
 name: Vol_up
 type: parsed
 protocol: NECext
@@ -46,22 +29,12 @@ protocol: NECext
 address: 00 7F 00 00
 command: 16 E9 00 00
 
-#
-# ==================================================
-# CHANNEL CONTROL
-# ==================================================
-#
 name: Ch_up
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 19 E6 00 00
 
-#
-# ==================================================
-# NAVIGATION (ALL VALIDATED)
-# ==================================================
-#
 name: Up
 type: parsed
 protocol: NECext
@@ -92,11 +65,6 @@ protocol: NECext
 address: 00 7F 00 00
 command: 11 EE 00 00
 
-#
-# ==================================================
-# INPUT / SOURCES
-# ==================================================
-#
 name: Input
 type: parsed
 protocol: NECext
@@ -115,11 +83,6 @@ protocol: NECext
 address: 00 7F 00 00
 command: 4C B3 00 00
 
-#
-# ==================================================
-# MENUS & NAVIGATION
-# ==================================================
-#
 name: Settings
 type: parsed
 protocol: NECext
@@ -150,22 +113,12 @@ protocol: NECext
 address: 00 7F 00 00
 command: 32 CD 00 00
 
-#
-# ==================================================
-# RECORDING
-# ==================================================
-#
 name: Record
 type: parsed
 protocol: NECext
 address: 00 7F 00 00
 command: 24 DB 00 00
 
-#
-# ==================================================
-# STREAMING APPS (DIRECT LAUNCH)
-# ==================================================
-#
 name: Netflix
 type: parsed
 protocol: NECext
@@ -190,11 +143,6 @@ protocol: NECext
 address: 00 7F 00 00
 command: 1E E1 00 00
 
-#
-# ==================================================
-# REMOTE / ADVANCED
-# ==================================================
-#
 name: Pair_Remote
 type: parsed
 protocol: NECext

--- a/TVs/ContinentalEdison/ContinentalEdison_CELD55SQLDV24B6.ir
+++ b/TVs/ContinentalEdison/ContinentalEdison_CELD55SQLDV24B6.ir
@@ -1,0 +1,202 @@
+Filetype: IR signals file
+Version: 1
+
+#
+# Device: Continental Edison Smart TV
+# Model: CELD55SQLDV24B6
+# Protocol: NEC Extended (NECext)
+# IR Address: 00 7F 00 00
+#
+
+# Author: Kakuzu (original discovery and validation)
+# Contact: Telegram/Discord - @kakuzu_f0
+# Source: Personal reverse engineering with Flipper Zero
+
+#
+# ==================================================
+# SYSTEM POWER
+# ==================================================
+#
+name: Power
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 15 EA 00 00
+
+#
+# ==================================================
+# AUDIO CONTROL
+# ==================================================
+#
+name: Vol_up
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 1B E4 00 00
+
+name: Vol_dn
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 1A E5 00 00
+
+name: Mute
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 16 E9 00 00
+
+#
+# ==================================================
+# CHANNEL CONTROL
+# ==================================================
+#
+name: Ch_up
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 19 E6 00 00
+
+#
+# ==================================================
+# NAVIGATION (ALL VALIDATED)
+# ==================================================
+#
+name: Up
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 0C F3 00 00
+
+name: Down
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 0D F2 00 00
+
+name: Right
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 0E F1 00 00
+
+name: Left
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 0F F0 00 00
+
+name: OK
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 11 EE 00 00
+
+#
+# ==================================================
+# INPUT / SOURCES
+# ==================================================
+#
+name: Input
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 12 ED 00 00
+
+name: Satellite
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 18 E7 00 00
+
+name: USB
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 4C B3 00 00
+
+#
+# ==================================================
+# MENUS & NAVIGATION
+# ==================================================
+#
+name: Settings
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 17 E8 00 00
+
+name: App_Menu
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 25 DA 00 00
+
+name: Account
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 21 DE 00 00
+
+name: Home
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 42 BD 00 00
+
+name: Exit
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 32 CD 00 00
+
+#
+# ==================================================
+# RECORDING
+# ==================================================
+#
+name: Record
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 24 DB 00 00
+
+#
+# ==================================================
+# STREAMING APPS (DIRECT LAUNCH)
+# ==================================================
+#
+name: Netflix
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 50 AF 00 00
+
+name: YouTube
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 4F B0 00 00
+
+name: Prime_Video
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 1C E3 00 00
+
+name: Disney_Plus
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 1E E1 00 00
+
+#
+# ==================================================
+# REMOTE / ADVANCED
+# ==================================================
+#
+name: Pair_Remote
+type: parsed
+protocol: NECext
+address: 00 7F 00 00
+command: 4E B1 00 00

--- a/TVs/ContinentalEdison/ContinentalEdison_CELD55SQLDV24B6.ir
+++ b/TVs/ContinentalEdison/ContinentalEdison_CELD55SQLDV24B6.ir
@@ -2,8 +2,6 @@ Filetype: IR signals file
 Version: 1
 #
 # Continental Edison CELD55SQLDV24B6 TV
-# Protocol: NECext
-# Address: 00 7F 00 00
 #
 name: Power
 type: parsed


### PR DESCRIPTION
## Added Device
- **Brand:** Continental Edison
- **Model:** CELD55SQLDV24B6
- **Protocol:** NECext
- **Address:** 00 7F 00 00

## Validated Buttons (24 working codes)
- Power, Volume (up/dn), Mute
- Channel Up
- Navigation (Up, Down, Left, Right, OK, Home, Exit)
- Input/Sources (Input, Satellite, USB)
- Menus (Settings, App_Menu, Account)
- Recording
- Streaming apps (Netflix, YouTube, Prime Video, Disney+)
- Pair Remote

## Author
@kakuzu_f0 (Telegram/Discord)
