### PR TITLE
Philips Soundbar HTL2060

### DIFF
--- a/Audio_and_Video_Receivers/Philips/Philips Soundbar-HTL2060_94.ir
+++ b/Audio_and_Video_Receivers/Philips/Philips Soundbar-HTL2060_94.ir
@@ -1,0 +1,80 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: ON_OFF
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 0C 00 00 00
+# 
+name: Reset
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 0E 00 00 00
+# 
+name: Mute
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 0D 00 00 00
+# 
+name: Play_Pause
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 30 00 00 00
+# 
+name: Vol UP
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 10 00 00 00
+# 
+name: Vol DOWN
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 11 00 00 00
+# 
+name: Prev
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 21 00 00 00
+# 
+name: Next
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 20 00 00 00
+# 
+name: BT
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 86 00 00 00
+# 
+name: ARC
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 7D 00 00 00
+# 
+name: OPT
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 6C 00 00 00
+# 
+name: AUD
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 39 00 00 00
+# 
+name: USB
+type: parsed
+protocol: RC6
+address: 20 00 00 00
+command: 87 00 00 00

--- a/Audio_and_Video_Receivers/Philips/Philips Soundbar-HTL2060_94.ir
+++ b/Audio_and_Video_Receivers/Philips/Philips Soundbar-HTL2060_94.ir
@@ -1,7 +1,7 @@
 Filetype: IR signals file
 Version: 1
 # 
-name: ON_OFF
+name: Power
 type: parsed
 protocol: RC6
 address: 20 00 00 00
@@ -25,13 +25,13 @@ protocol: RC6
 address: 20 00 00 00
 command: 30 00 00 00
 # 
-name: Vol UP
+name: Vol_up
 type: parsed
 protocol: RC6
 address: 20 00 00 00
 command: 10 00 00 00
 # 
-name: Vol DOWN
+name: Vol_dn
 type: parsed
 protocol: RC6
 address: 20 00 00 00


### PR DESCRIPTION
Philips Soundbar HTL2060/94 remote .ir file. I have tested it on my own soundbar.

ISSUES-
- The remote has an “EQ” button, that cycles the equaliser between, POP, ROCK, JAZZ, CLASSIC, COUNTRY, NORMAL. I wasn’t able to record this signal, and rest all of them work.

I’ll try to update this file soon and include it by coding it manually.