### PR TITLE
Add Mastercool MCP59 window evaporative cooler (ACs/Mastercool)

### DIFF
--- a/ACs/Mastercool/Mastercool_MCP59.ir
+++ b/ACs/Mastercool/Mastercool_MCP59.ir
@@ -1,0 +1,26 @@
+Filetype: IR signals file
+Version: 1
+#
+# Mastercool / Champion "MasterLink" window evaporative cooler
+# Compatible models: MCP44, MCP44E, MCP59, WPL44NP (OEM remote part #72302)
+# Protocol: raw 38kHz, ~545us base period, 6-bit address 110110 + one-hot 6-bit command
+# Power = whole unit toggle | Fan = speed cycle (Hi/Med/Lo) | Pump = water pump toggle
+# Verified on an MCP59; codes derived from the shared Champion IR protocol
+#
+name: Power
+type: raw
+frequency: 38000
+duty_cycle: 0.330000
+data: 1090 545 1090 545 545 1090 1090 545 1090 545 545 1090 545 1090 1090 545 545 1090 545 1090 545 1090 545 7630 1090 545 1090 545 545 1090 1090 545 1090 545 545 1090 545 1090 1090 545 545 1090 545 1090 545 1090 545 7630
+#
+name: Fan
+type: raw
+frequency: 38000
+duty_cycle: 0.330000
+data: 1090 545 1090 545 545 1090 1090 545 1090 545 545 1090 545 1090 545 1090 545 1090 1090 545 545 1090 545 7630 1090 545 1090 545 545 1090 1090 545 1090 545 545 1090 545 1090 545 1090 545 1090 1090 545 545 1090 545 7630
+#
+name: Pump
+type: raw
+frequency: 38000
+duty_cycle: 0.330000
+data: 1090 545 1090 545 545 1090 1090 545 1090 545 545 1090 545 1090 545 1090 1090 545 545 1090 545 1090 545 7630 1090 545 1090 545 545 1090 1090 545 1090 545 545 1090 545 1090 545 1090 1090 545 545 1090 545 1090 545 7630


### PR DESCRIPTION
Adds a new remote for the Mastercool / Champion "MasterLink" window
evaporative cooler, a device that previously had no IR codes available
anywhere public.

File: ACs/Mastercool/Mastercool_MCP59.ir

Details:
- Compatible models: MCP44, MCP44E, MCP59, WPL44NP (share the OEM remote,
  part #72302).
- Protocol: raw 38kHz, ~545us base period, 6-bit address (110110) followed
  by a one-hot 6-bit command.
- Buttons: Power (whole-unit toggle), Fan (speed cycle Hi/Med/Lo), Pump
  (water pump toggle).
- Verified working on an MCP59.

Button naming: the standard AC scheme (Off/Cool_hi/Cool_lo/etc.) doesn't map
to an evaporative cooler, which has no temperature setpoint or heat/cool
modes. I've used descriptive names matching the actual hardware, consistent
with the existing Bonaire evaporative-cooler entry.

Note: each signal is sent twice, which the unit requires to register a
command. Happy to split to single-frame if preferred.