### PR TITLE
Add Harman Kardon Enchant 800 soundbar

### DIFF
--- a/SoundBars/Harman_Kardon/Harman_Kardon_Enchant_800.ir
+++ b/SoundBars/Harman_Kardon/Harman_Kardon_Enchant_800.ir
@@ -1,0 +1,73 @@
+Filetype: IR signals file
+Version: 1
+#
+# Harman Kardon Enchant 800 soundbar
+# Protocol: NECext. Power on address 7484; all other functions on 7080.
+# Captured/verified on real hardware. Very likely also covers the Enchant 1300
+# (same remote family). The Enchant shares the JBL Boost/5.1 soundbar IR map.
+#
+name: Power
+type: parsed
+protocol: NECext
+address: 84 74 00 00
+command: FF 00 00 00
+#
+name: Source
+type: parsed
+protocol: NECext
+address: 80 70 00 00
+command: B9 46 00 00
+#
+name: Vol_up
+type: parsed
+protocol: NECext
+address: 80 70 00 00
+command: C7 38 00 00
+#
+name: Vol_dn
+type: parsed
+protocol: NECext
+address: 80 70 00 00
+command: C8 37 00 00
+#
+name: Mute
+type: parsed
+protocol: NECext
+address: 80 70 00 00
+command: C1 3E 00 00
+#
+name: Bluetooth
+type: parsed
+protocol: NECext
+address: 80 70 00 00
+command: BA 45 00 00
+#
+name: Bass_up
+type: parsed
+protocol: NECext
+address: 80 70 00 00
+command: EC 13 00 00
+#
+name: Bass_dn
+type: parsed
+protocol: NECext
+address: 80 70 00 00
+command: ED 12 00 00
+#
+name: Prev
+type: parsed
+protocol: NECext
+address: 80 70 00 00
+command: 25 DA 00 00
+#
+name: Play_Pause
+type: parsed
+protocol: NECext
+address: 80 70 00 00
+command: 03 FC 00 00
+#
+name: Next
+type: parsed
+protocol: NECext
+address: 80 70 00 00
+command: 24 DB 00 00


### PR DESCRIPTION
Adds SoundBars/Harman_Kardon/Harman_Kardon_Enchant_800.ir

11 buttons, NECext. Power is on address 0x7484; all other functions
(Source, Vol +/-, Mute, Bluetooth, Bass +/-, Prev/Play-Pause/Next) on 0x7080.

Each code was tested against a real Enchant 800. The Enchant shares the JBL
Boost/5.1 IR map, so this very likely also covers the Enchant 1300 (same remote).
