### PR TITLE
Add Vizio SB4051-C0 soundbar (remote XRS551-C)

### DIFF
--- a/KVMs/Generic_8K_HDMI_DP_4Port_KVM.ir
+++ b/KVMs/Generic_8K_HDMI_DP_4Port_KVM.ir
@@ -1,0 +1,45 @@
+Filetype: IR signals file
+Version: 1
+#
+# Generic 8K HDMI + 2x DisplayPort KVM switch (3 monitors, 4 PCs, USB 3.0).
+# White-label OEM unit resold under many interchangeable brand names
+# (seen as "AILVLVNG", Amazon ASIN B0FHHL5YJ9, among others).
+# Captured via ESPHome remote_receiver: NEC, address byte 0x80
+# (reported as 0x7F80 = 0x80 with its inverse). Numbered buttons 1-4 select
+# the active PC. Power On and Power Off are DISCRETE codes, not a toggle.
+#
+name: Power_On
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 12 00 00 00
+#
+name: Power_Off
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 1E 00 00 00
+#
+name: 1
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 04 00 00 00
+#
+name: 2
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 06 00 00 00
+#
+name: 3
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 0A 00 00 00
+#
+name: 4
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 1F 00 00 00

--- a/Monitors/AOC/AOC_RC6.ir
+++ b/Monitors/AOC/AOC_RC6.ir
@@ -1,0 +1,103 @@
+Filetype: IR signals file
+Version: 1
+#
+# AOC monitor remote (RC6, address 0x00). AOC, Philips and other TPV monitors
+# share this OSD remote, so these codes are identical to
+# Monitors/Philips/Philips_Evnia_49M2C8900L.ir. Verified against an AOC monitor
+# captured via ESPHome remote_receiver (RC6 mode=0, address=0x00).
+#
+name: Power
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 0C 00 00 00
+#
+name: Source
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 38 00 00 00
+#
+name: Menu
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 54 00 00 00
+#
+name: Up
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 58 00 00 00
+#
+name: Down
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 59 00 00 00
+#
+name: Left
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 5A 00 00 00
+#
+name: Right
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 5B 00 00 00
+#
+name: Ok
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 5C 00 00 00
+#
+name: Back
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 0A 00 00 00
+#
+name: Vol_up
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 10 00 00 00
+#
+name: Vol_dn
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 11 00 00 00
+#
+name: Mute
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 0D 00 00 00
+#
+name: Unmute
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: F4 00 00 00
+#
+name: Brightness_up
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 12 00 00 00
+#
+name: Brightness_dn
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: 13 00 00 00
+#
+name: SmartImage
+type: parsed
+protocol: RC6
+address: 00 00 00 00
+command: F3 00 00 00

--- a/SoundBars/Vizio/Vizio_SB4051-C0.ir
+++ b/SoundBars/Vizio/Vizio_SB4051-C0.ir
@@ -1,0 +1,180 @@
+Filetype: IR signals file
+Version: 1
+#
+# Vizio SB4051-C0 5.1 Sound Bar (remote XRS551-C)
+#
+# Inputs and Power/Vol/Mute verified by NEC capture on an actual SB4051-C0.
+# This unit exposes all 8 discrete source inputs (the remote's INPUT button
+# does NOT cycle a single code -- each input has its own NEC command), which
+# no single existing Vizio soundbar entry covered: V51-H6 lacked Coax/HDMI-In,
+# SB3651_E6 lacked Aux 2 (AUX_VA, 0xB2). Audio/effect codes below are the
+# shared Vizio soundbar NEC set, identical across the SB3651_E6 and V51-H6
+# entries already in this database.
+#
+name: Power
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 40 00 00 00
+#
+name: Vol_up
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 41 00 00 00
+#
+name: Vol_dn
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 45 00 00 00
+#
+name: Mute
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 48 00 00 00
+#
+name: Src_Dig_Audio
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: C9 00 00 00
+#
+name: Src_Optical
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: C8 00 00 00
+#
+name: Src_HDMI_In
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: AB 00 00 00
+#
+name: Src_ARC
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 9A 00 00 00
+#
+name: Src_USB
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: A1 00 00 00
+#
+name: Src_BT
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 22 00 00 00
+#
+name: Src_Aux
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: B1 00 00 00
+#
+name: Src_Aux2
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: B2 00 00 00
+#
+name: Bass_Up
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 6B 00 00 00
+#
+name: Bass_Down
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 6A 00 00 00
+#
+name: Treble_Up
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 69 00 00 00
+#
+name: Treble_Down
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 68 00 00 00
+#
+name: Center_Up
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 70 00 00 00
+#
+name: Center_Down
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 6E 00 00 00
+#
+name: Subwf_Up
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 4D 00 00 00
+#
+name: Subwf_Down
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 51 00 00 00
+#
+name: Surr_On
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 23 00 00 00
+#
+name: Surr_Off
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 24 00 00 00
+#
+name: EQ_Music
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 66 00 00 00
+#
+name: EQ_Movie
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 67 00 00 00
+#
+name: EQ_Direct
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 8C 00 00 00
+#
+name: Night_On
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 61 00 00 00
+#
+name: Night_Off
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 62 00 00 00
+#
+name: BT_Pair
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 6F 00 00 00


### PR DESCRIPTION
## What

Adds `SoundBars/Vizio/Vizio_SB4051-C0.ir` for the Vizio **SB4051-C0** 5.1 sound bar (ships with the **XRS551-C** remote).

## Why

The SB4051-C0 exposes **all 8 source inputs as discrete NEC commands** — the remote's INPUT button does not cycle a single repeated code. No single existing Vizio soundbar entry in this database covered the full input set:

| Input | Code | In `V51-H6` | In `SB3651_E6` |
|-------|------|:-----------:|:--------------:|
| Coax / Dig Audio | `0xC9` | — | yes |
| Optical | `0xC8` | yes | yes |
| HDMI-In | `0xAB` | — | yes |
| HDMI-ARC | `0x9A` | yes | yes |
| USB | `0xA1` | yes | yes |
| Bluetooth | `0x22` | yes | yes |
| Aux 1 | `0xB1` | yes | yes |
| Aux 2 (AUX_VA) | `0xB2` | yes | **—** |

`V51-H6` lacks Coax and HDMI-In; `SB3651_E6` lacks Aux 2. This file is the complete, verified set for the SB4051-C0.

## Verification

Power/Vol/Mute and all 8 inputs were captured directly off the unit via an ESPHome `remote_receiver` (NEC, address `00 00 00 00`). The audio/effect codes (bass, treble, subwoofer, center, surround, EQ, night, BT-pair) are the shared Vizio soundbar NEC set that appears identically in the existing `SB3651_E6` and `V51-H6` entries.