### PR TITLE
Add generic 8K HDMI + 2x DisplayPort 4-port KVM switch

### DIFF
--- a/KVMs/Generic_8K_HDMI_DP_4Port_KVM.ir
+++ b/KVMs/Generic_8K_HDMI_DP_4Port_KVM.ir
@@ -1,0 +1,45 @@
+Filetype: IR signals file
+Version: 1
+#
+# Generic 8K HDMI + 2x DisplayPort KVM switch (3 monitors, 4 PCs, USB 3.0).
+# White-label OEM unit resold under many interchangeable brand names
+# (seen as "AILVLVNG", Amazon ASIN B0FHHL5YJ9, among others).
+# Captured via ESPHome remote_receiver: NEC, address byte 0x80
+# (reported as 0x7F80 = 0x80 with its inverse). Numbered buttons 1-4 select
+# the active PC. Power On and Power Off are DISCRETE codes, not a toggle.
+#
+name: Power_On
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 12 00 00 00
+#
+name: Power_Off
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 1E 00 00 00
+#
+name: 1
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 04 00 00 00
+#
+name: 2
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 06 00 00 00
+#
+name: 3
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 0A 00 00 00
+#
+name: 4
+type: parsed
+protocol: NEC
+address: 80 00 00 00
+command: 1F 00 00 00


### PR DESCRIPTION
## What

Adds `KVMs/Generic_8K_HDMI_DP_4Port_KVM.ir` — a white-label 8K HDMI + 2x DisplayPort KVM switch (3 monitors, 4 PCs, USB 3.0), resold under interchangeable brand names (seen as "AILVLVNG", ASIN B0FHHL5YJ9).

## Codes

NEC, address byte `0x80`. Buttons 1-4 select the active PC. **Power On (`0x12`) and Power Off (`0x1E`) are discrete** (not a single toggle).

| Button | NEC command |
|--------|:-----------:|
| Power_On | `0x12` |
| Power_Off | `0x1E` |
| 1 | `0x04` |
| 2 | `0x06` |
| 3 | `0x0A` |
| 4 | `0x1F` |

## Verification

Captured from the unit via an ESPHome `remote_receiver` (NEC, address `0x80` / `0x7F80` with inverse). Checked against the existing database: `0x80` is the shared chipset address used by many cheap HDMI/KVM switches, but **no existing entry carries this command set**, so this is a new device rather than a duplicate.

> Note on placement: filed under a new `KVMs/` folder. Happy to move it under `Miscellaneous/Brand_Unknown/` (where other generic HDMI switches live) if preferred.